### PR TITLE
Network simulator

### DIFF
--- a/slower/client/proxy/ray_client_proxy.py
+++ b/slower/client/proxy/ray_client_proxy.py
@@ -13,6 +13,7 @@ from slower.server.server_model.manager.server_model_manager import ServerModelM
 from slower.server.server_model.proxy.ray_private_server_model_proxy import (
     RayPrivateServerModelProxy
 )
+from slower.simulation.utlis.network_simulator import NetworkSimulator
 
 
 class RayClientProxy(RayActorClientProxy):
@@ -21,10 +22,12 @@ class RayClientProxy(RayActorClientProxy):
     def __init__(
         self,
         server_model_manager: ServerModelManager,
+        network_simulator: Optional[NetworkSimulator] = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
         self.server_model_manager = server_model_manager
+        self.network_simulator = network_simulator
 
     def fit(
         self,
@@ -36,7 +39,8 @@ class RayClientProxy(RayActorClientProxy):
         def fit(client: Client) -> common.FitRes:
             server_model_proxy = RayPrivateServerModelProxy(
                 server_model,
-                request_queue_in_separate_thread=True
+                request_queue_in_separate_thread=True,
+                network_simulator=self.network_simulator
             )
             # also return the server_model_proxy, so that we can store it outside the
             # ray actor to the shared ray memory

--- a/slower/server/server_model/proxy/ray_private_server_model_proxy.py
+++ b/slower/server/server_model/proxy/ray_private_server_model_proxy.py
@@ -34,9 +34,6 @@ class RayPrivateServerModelProxy(ServerModelProxy):
 
     def _streaming_request(self, method, batch_data):
         if self.request_queue is not None:
-
-            if self.network_simulator is not None:
-                self.network_simulator.simulate_network(batch_data=batch_data)
             self.request_queue.put((method, batch_data))
         else:
             self._blocking_request(method=method, batch_data=batch_data, timeout=None)
@@ -51,6 +48,8 @@ class RayPrivateServerModelProxy(ServerModelProxy):
             for method, batch in iterator:
                 if batch.control_code == ControlCode.DO_CLOSE_STREAM:
                     break
+                if server_proxy.network_simulator is not None:
+                    server_proxy.network_simulator.simulate_network(batch_data=batch)
                 server_proxy._blocking_request(method, batch, None)
 
         self.request_queue = SimpleQueue()

--- a/slower/simulation/utlis/network_simulator.py
+++ b/slower/simulation/utlis/network_simulator.py
@@ -1,0 +1,51 @@
+import time
+import random
+import sys
+from slower.common import BatchData
+
+
+class NetworkSimulator:
+    def __init__(self, avg_latency_ms, latency_variance_ms, avg_bandwidth_mbps, bandwidth_variance_mbps):
+        self.avg_latency_ms = avg_latency_ms
+        self.latency_variance_ms = latency_variance_ms
+        self.avg_bandwidth_mbps = avg_bandwidth_mbps
+        self.bandwidth_variance_mbps = bandwidth_variance_mbps
+
+    def simulate_latency(self):
+        latency = random.gauss(self.avg_latency_ms, self.latency_variance_ms)
+        time.sleep(max(0, latency) / 1000)
+
+    def simulate_bandwidth(self, data_size):
+        bandwidth_mbps = max(0, random.gauss(self.avg_bandwidth_mbps, self.bandwidth_variance_mbps))
+        if bandwidth_mbps > 0:
+            transfer_time = data_size / (bandwidth_mbps * 1024 * 1024 / 8)
+            time.sleep(transfer_time)
+
+    def simulate_network(self, batch_data: BatchData):
+        data_size = get_data_size(batch_data)
+        self.simulate_latency()
+        self.simulate_bandwidth(data_size)
+
+
+def get_data_size(batch_data) -> int:
+    def get_size(obj, seen=None):
+        """Recursively finds size of objects"""
+        size = sys.getsizeof(obj)
+        if seen is None:
+            seen = set()
+        obj_id = id(obj)
+        if obj_id in seen:
+            return 0
+        # Important mark as seen *before* entering recursion to gracefully handle
+        # self-referential objects
+        seen.add(obj_id)
+        if isinstance(obj, dict):
+            size += sum([get_size(v, seen) for v in obj.values()])
+            size += sum([get_size(k, seen) for k in obj.keys()])
+        elif hasattr(obj, '__dict__'):
+            size += get_size(vars(obj), seen)
+        elif hasattr(obj, '__iter__') and not isinstance(obj, (str, bytes, bytearray)):
+            size += sum([get_size(i, seen) for i in obj])
+        return size
+
+    return get_size(batch_data)


### PR DESCRIPTION
I added a simple network latency simulator feature to the simulation.

The feature can be used by providing an optional kwarg dictionary:
```
start_simulation(
        ...,
        network_simulator_kwargs={"avg_latency_ms": 550, "latency_variance_ms": 50,
                                  "avg_bandwidth_mbps": 100, "bandwidth_variance_mbps": 10},
    )
```
By default `network_simulator_kwargs = None` and the simulator is not used, and will only be used if the `network_simulator_kwargs` is provided.